### PR TITLE
优化打印时性能

### DIFF
--- a/src/main/java/me/aleksilassila/litematica/printer/printer/PlacementGuide.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/printer/PlacementGuide.java
@@ -42,6 +42,10 @@ public class PlacementGuide extends PrinterUtils {
     }
 
     public @Nullable Action getAction(World world, WorldSchematic worldSchematic, BlockPos pos) {
+		//提前判断方块状态避免无用循环
+		State state = State.get(worldSchematic.getBlockState(pos), world.getBlockState(pos));
+		if (state == State.CORRECT)
+            return null;
         for (ClassHook hook : ClassHook.values()) {
             for (Class<?> clazz : hook.classes) {
                 if (clazz != null  && clazz.isInstance(worldSchematic.getBlockState(pos).getBlock())) {

--- a/src/main/java/me/aleksilassila/litematica/printer/printer/Printer.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/printer/Printer.java
@@ -557,7 +557,6 @@ public class Printer extends PrinterUtils {
         while ((pos = getBlockPos2()) != null) {
             if (client.player != null && !canInteracted(pos)) continue;
             BlockState requiredState = worldSchematic.getBlockState(pos);
-            PlacementGuide.Action action = guide.getAction(world, worldSchematic, pos);
 
             //跳过放置
             if (LitematicaMixinMod.PUT_SKIP.getBooleanValue() &&
@@ -572,6 +571,8 @@ public class Printer extends PrinterUtils {
             }else {
                 skipPosMap.put(pos,0);
             }
+
+           PlacementGuide.Action action = guide.getAction(world, worldSchematic, pos);
 
             if(USE_EASY_MODE.getBooleanValue() && action != null) {
                 easyPos = pos;

--- a/src/main/java/me/aleksilassila/litematica/printer/printer/State.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/printer/State.java
@@ -3,9 +3,9 @@ package me.aleksilassila.litematica.printer.printer;
 import fi.dy.masa.malilib.config.IConfigOptionListEntry;
 import fi.dy.masa.malilib.util.StringUtils;
 import me.aleksilassila.litematica.printer.LitematicaMixinMod;
-import me.aleksilassila.litematica.printer.printer.zxy.Utils.Filters;
 import net.minecraft.block.BlockState;
-//import net.minecraft.util.registry.Registry;
+import java.util.HashSet;
+import java.util.Set;
 
 public enum State {
     MISSING_BLOCK,

--- a/src/main/java/me/aleksilassila/litematica/printer/printer/State.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/printer/State.java
@@ -14,26 +14,18 @@ public enum State {
     CORRECT;
 
     public static State get(BlockState schematicBlockState, BlockState currentBlockState) {
-//        if(currentBlockState.getBlock() instanceof FluidBlock){
-//            System.out.println(Registries.BLOCK.getId(currentBlockState.getBlock()));
-//        }
-        if (!schematicBlockState.isAir() && (currentBlockState.isAir() ||
-                (LitematicaMixinMod.REPLACEABLE_LIST.getStrings().stream()
-                        .anyMatch(string -> !Filters.equalsName(string,schematicBlockState) &&
-//                        .anyMatch(string -> !Registries.BLOCK.getId(schematicBlockState.getBlock()).toString().contains(string) &&
-//                                Registries.BLOCK.getId(currentBlockState.getBlock()).toString().contains(string)) &&
-                                Filters.equalsName(string,currentBlockState)) &&
-                        LitematicaMixinMod.REPLACE.getBooleanValue())))
-//        if (!schematicBlockState.isAir() && (currentBlockState.isAir() || currentBlockState.getBlock() instanceof FluidBlock || currentBlockState.isOf(Blocks.SNOW) || currentBlockState.isOf(Blocks.BUBBLE_COLUMN)))
-//        if (!schematicBlockState.isAir() && (currentBlockState.isAir())
-            return State.MISSING_BLOCK;
-        else if (schematicBlockState.getBlock().equals(currentBlockState.getBlock())
-                && !schematicBlockState.equals(currentBlockState))
-            return State.WRONG_STATE;
-        else if (!schematicBlockState.getBlock().equals(currentBlockState.getBlock()))
-            return WRONG_BLOCK;
 
-        return State.CORRECT;
+        Set<String> replaceSet = new HashSet<>(LitematicaMixinMod.REPLACEABLE_LIST.getStrings());
+
+        if (schematicBlockState == currentBlockState)
+            return CORRECT;
+        else if (schematicBlockState.getBlock().getDefaultState() == currentBlockState.getBlock().getDefaultState())
+            return WRONG_STATE;
+        else if (!schematicBlockState.isAir() && currentBlockState.isAir())
+            return MISSING_BLOCK;
+        else if (LitematicaMixinMod.REPLACE.getBooleanValue() && replaceSet.contains(schematicBlockState.getBlock().getTranslationKey()))
+            return MISSING_BLOCK;
+        else return WRONG_BLOCK;
     }
 
 


### PR DESCRIPTION
提升了State判断的性能
把Printer.tick()里getAction往后移减少不必要的判断，以及预防一些特殊bug
在PlacementGuide.getAction添加了循环之前的判断，减少在正确状态下投影方块的不必要循环